### PR TITLE
Adjust calendar responsive behavior

### DIFF
--- a/app/javascript/components/Calendar.css
+++ b/app/javascript/components/Calendar.css
@@ -1,0 +1,26 @@
+@media screen and (max-width: 640px) {
+  .fc .fc-toolbar-title {
+    font-size: 1rem;
+  }
+
+  .fc .fc-button {
+    padding: 0.2rem;
+    font-size: 0.75rem;
+  }
+
+  .fc .fc-view-harness-active {
+    height: 80vh !important;
+  }
+
+  .fc .fc-toolbar.fc-header-toolbar {
+    margin-bottom: 0.5rem;
+  }
+
+  .fc table {
+    font-size: 0.75rem;
+  }
+}
+
+/* 
+fc-view-harness fc-view-harness-active
+*/

--- a/app/javascript/components/Calendar.js
+++ b/app/javascript/components/Calendar.js
@@ -3,6 +3,7 @@ import FullCalendar from '@fullcalendar/react'
 import dayGridPlugin from '@fullcalendar/daygrid'
 import timeGridPlugin from '@fullcalendar/timegrid'
 import interactionPlugin from "@fullcalendar/interaction"
+import "./Calendar.css"
 
 class Calendar extends React.Component {
   constructor(props) {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,3 @@
-<div class="p-8">
+<div class="p-4 sm:p-8">
   <%= react_component("Calendar") %>
 </div>


### PR DESCRIPTION
1. 新增 Calendar.css 針對幾個 class 調整 responsive 的行為。 "fc-view-harness-active" 這個 class 因為他的高度本身會隨著視窗大小變動，我覺得月曆格子本身在手持裝置如果還有 scroll bar 可能不好操作，所以另外設定高度。可能需要請 wh 確認一下這個寫法。

2. 調整 index.html.erb 的 Calendar 的 class 為 "p-4 sm:p-8" 。
